### PR TITLE
Unified accessory attaching to remove copypaste

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -25,9 +25,7 @@
 			if(4) H.equip_or_collect(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
 		H.equip_or_collect(new H.species.survival_gear(H.back), slot_in_backpack)
 		var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
-		var/obj/item/clothing/accessory/medal/gold/captain/medal = new
-		U.accessories += medal
-		medal.on_attached(U, null)
+		U.attach_accessory(new /obj/item/clothing/accessory/medal/gold/captain)
 		H.equip_or_collect(U, slot_w_uniform)
 		//H.equip_or_collect(new /obj/item/device/pda/captain(H), slot_belt)
 		H.equip_or_collect(new /obj/item/clothing/shoes/brown(H), slot_shoes)

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -25,16 +25,10 @@
 /obj/item/clothing/accessory/proc/can_attach_to(obj/item/clothing/C)
 	return istype(C, /obj/item/clothing/under) //By default, accessories can only be attached to jumpsuits
 
-/obj/item/clothing/accessory/proc/on_attached(obj/item/clothing/C, mob/user as mob)
+/obj/item/clothing/accessory/proc/on_attached(obj/item/clothing/C)
 	if(!istype(C))
 		return
 	attached_to = C
-	if(user)
-		if(user.drop_item(src, attached_to))
-			to_chat(user, "<span class='notice'>You attach [src] to [attached_to].</span>")
-			add_fingerprint(user)
-	else
-		forceMove(attached_to)
 	attached_to.overlays += inv_overlay
 
 /obj/item/clothing/accessory/proc/on_removed(mob/user as mob)

--- a/code/modules/clothing/accessories/holster.dm
+++ b/code/modules/clothing/accessories/holster.dm
@@ -15,7 +15,7 @@
 		return
 
 	if (!can_holster(I))
-		to_chat(user, "<span class='warning'>This [I] won't fit in the [src]!</span>")
+		to_chat(user, "<span class='warning'>\The [I] won't fit in the [src]!</span>")
 		return
 
 	if(user.drop_item(I, src))
@@ -92,7 +92,7 @@
 	else
 		to_chat(user, "It is empty.")
 
-/obj/item/clothing/accessory/holster/on_attached(obj/item/clothing/under/S, mob/user as mob)
+/obj/item/clothing/accessory/holster/on_attached(obj/item/clothing/under/S)
 	..()
 	attached_to.verbs += /obj/item/clothing/accessory/holster/verb/holster_verb
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -32,9 +32,9 @@
 			to_chat(user, "<span class='notice'>\The [A] cannot be attached to [src].</span>")
 			return
 		if(user.drop_item(I, src))
-			accessories.Add(A)
-			A.on_attached(src, user)
-			update_verbs()
+			to_chat(user, "<span class='notice'>You attach [A] to [src].</span>")
+			attach_accessory(A)
+			A.add_fingerprint(user)
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc
 			H.update_inv_by_slot(slot_flags)
@@ -61,6 +61,12 @@
 				return 1
 		return
 	return ..()
+
+/obj/item/clothing/proc/attach_accessory(obj/item/clothing/accessory/accessory)
+	accessories += accessory
+	accessory.forceMove(src)
+	accessory.on_attached(src)
+	update_verbs()
 
 /obj/item/clothing/proc/priority_accessories()
 	if(!accessories.len)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -251,9 +251,8 @@
 	bonus_kick_damage = 3
 
 /obj/item/clothing/shoes/jackboots/knifeholster/New() //This one comes with preloaded knife holster
-	var/obj/item/clothing/accessory/holster/knife/boot/preloaded/holster = new(src)
-	accessories += holster
-	holster.on_attached(src, null)
+	..()
+	attach_accessory(new /obj/item/clothing/accessory/holster/knife/boot/preloaded)
 
 /obj/item/clothing/shoes/jackboots/batmanboots
 	name = "batboots"


### PR DESCRIPTION
Also fixed a holster message displaying "This the" and a non-inherited New().
You would have had the issue of the prespawned holster not calling update_verbs, so the HoS wouldn't have been able to remove it, probably.
